### PR TITLE
Update 1.2.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,6 @@
+channels:
+  jaidarice: nbconvert-update
+build_parameters:
+  - "--suppress-variables"
+  - "--error-overlinking"
+  - "--error-overdepending"

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,3 @@
-channels:
-  jaidarice: nbconvert-update
 build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - pip
     - pytest-runner
     - setuptools
-    - webencodings 0.4
+    - webencodings >=0.4
     - wheel
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv
-  skip: True  # [py<37]
+  skip: True  #[py<37]
 
 requirements:
   host:
@@ -21,6 +21,7 @@ requirements:
     - pip
     - pytest-runner
     - webencodings >=0.4
+    - wheel
   run:
     - python
     - webencodings >=0.4
@@ -28,6 +29,10 @@ requirements:
 test:
   imports:
     - tinycss2
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
   home: https://www.courtbouillon.org/tinycss2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,9 +20,9 @@ requirements:
     - python
     - pip
     - pytest-runner
+    - setuptools
     - webencodings 0.4
     - wheel
-    - setuptools
   run:
     - python
     - webencodings >=0.4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,7 @@ requirements:
     - pytest-runner
     - webencodings 0.4
     - wheel
+    - setuptools
   run:
     - python
     - webencodings >=0.4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,16 +6,17 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/t/tinycss2/tinycss2-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 8cff3a8f066c2ec677c06dbc7b45619804a6938478d9d73c284b29d14ecb0627
 
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv
+  skip: True  # [py<37]
 
 requirements:
   host:
-    - flit
+    - flit-core >=3.2,<4
     - python
     - pip
     - pytest-runner
@@ -29,15 +30,16 @@ test:
     - tinycss2
 
 about:
-  home: https://github.com/Kozea/tinycss2
+  home: https://www.courtbouillon.org/tinycss2
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE
+  license_url: https://github.com/Kozea/tinycss2/blob/v{{ version }}/LICENSE
   summary: Low-level CSS parser for Python
   description: |
     tinycss2 is a rewrite of tinycss with a simpler API, based on the more recent
     CSS Syntax Level 3 Specification.
-  doc_url: http://tinycss2.readthedocs.io
+  doc_url: https://doc.courtbouillon.org/tinycss2/stable/
   dev_url: https://github.com/Kozea/tinycss2
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - pip
     - pytest-runner
     - setuptools
-    - webencodings >=0.4
+    - webencodings 0.5.1
     - wheel
   run:
     - python
@@ -40,14 +40,12 @@ about:
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE
-  license_url: https://github.com/Kozea/tinycss2/blob/v{{ version }}/LICENSE
   summary: Low-level CSS parser for Python
   description: |
     tinycss2 is a rewrite of tinycss with a simpler API, based on the more recent
     CSS Syntax Level 3 Specification.
   doc_url: https://doc.courtbouillon.org/tinycss2/stable/
   dev_url: https://github.com/Kozea/tinycss2
-  doc_source_url: https://github.com/Kozea/tinycss2/tree/v{{ version }}/docs
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,8 @@
+{% set name = "tinycss2" %}
 {% set version = "1.2.1" %}
 
 package:
-  name: tinycss2
+  name: {{ name }}
   version: {{ version }}
 
 source:
@@ -10,18 +11,17 @@ source:
 
 build:
   number: 0
-  noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
   host:
     - flit
-    - python >=3.5
+    - python
     - pip
     - pytest-runner
     - webencodings >=0.4
   run:
-    - python >=3.5
+    - python
     - webencodings >=0.4
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,6 +41,7 @@ about:
     CSS Syntax Level 3 Specification.
   doc_url: https://doc.courtbouillon.org/tinycss2/stable/
   dev_url: https://github.com/Kozea/tinycss2
+  doc_source_url: https://github.com/Kozea/tinycss2/tree/v{{ version }}/docs
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,11 +16,11 @@ build:
 
 requirements:
   host:
-    - flit-core >=3.2,<4
+    - flit-core 3.2
     - python
     - pip
     - pytest-runner
-    - webencodings >=0.4
+    - webencodings 0.4
     - wheel
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv
-  skip: True  #[py<37]
+  skip: True  # [py<37]
 
 requirements:
   host:


### PR DESCRIPTION
- Removed noarch and updated python pinnings
- Added skip
- Changed flit to flit-core (i.e. https://github.com/Kozea/tinycss2/blob/master/pyproject.toml#L2)
- Added wheel to host section and pip requires and pip check to test section (linter)
- Updated home and doc url
- Added license and doc source urls

Jira: https://anaconda.atlassian.net/browse/PKG-668
https://github.com/Kozea/tinycss2/blob/v1.2.1/pyproject.toml